### PR TITLE
Fix json issue with contract events

### DIFF
--- a/consumer/consumer_save_contract_events_to_postgresql.go
+++ b/consumer/consumer_save_contract_events_to_postgresql.go
@@ -146,6 +146,12 @@ func (p *SaveContractEventsToPostgreSQL) Process(ctx context.Context, msg proces
 		}
 	}()
 
+	// Convert topic to JSON
+	topicJSON, err := json.Marshal(contractEvent.Topic)
+	if err != nil {
+		return fmt.Errorf("failed to marshal topic: %w", err)
+	}
+
 	// Insert contract event
 	var contractEventID int64
 	err = tx.QueryRowContext(
@@ -160,7 +166,7 @@ func (p *SaveContractEventsToPostgreSQL) Process(ctx context.Context, msg proces
 		contractEvent.TransactionHash,
 		contractEvent.ContractID,
 		contractEvent.Type,
-		json.RawMessage(fmt.Sprintf("%v", contractEvent.Topic)), // Convert topic to JSON
+		topicJSON,
 		contractEvent.Data,
 		contractEvent.InSuccessfulTx,
 		contractEvent.EventIndex,


### PR DESCRIPTION
This pull request refactors how contract event topics are handled in the `Process` method of the `SaveContractEventsToPostgreSQL` struct. The changes improve the reliability and readability of the code by replacing an inline JSON conversion with a pre-marshaled JSON object.

### Key Changes:

**Improved JSON Handling for Contract Event Topics:**
* Added logic to pre-marshal `contractEvent.Topic` into a JSON object (`topicJSON`) before inserting it into the database. This ensures proper error handling and eliminates the need for inline conversion. (`consumer/consumer_save_contract_events_to_postgresql.go`, [consumer/consumer_save_contract_events_to_postgresql.goR149-R154](diffhunk://#diff-95b7202aee122ae01129d17d532b538b1b8c3dcfa035bcf446773c462d6f1939R149-R154))
* Updated the database query to use the pre-marshaled `topicJSON` instead of performing the JSON conversion inline. (`consumer/consumer_save_contract_events_to_postgresql.go`, [consumer/consumer_save_contract_events_to_postgresql.goL163-R169](diffhunk://#diff-95b7202aee122ae01129d17d532b538b1b8c3dcfa035bcf446773c462d6f1939L163-R169))