### PR TITLE
Bugfix/tmosley/fix container build

### DIFF
--- a/Dockerfile.nix
+++ b/Dockerfile.nix
@@ -1,0 +1,27 @@
+# Nix builder stage
+FROM nixos/nix:latest AS builder
+
+# Copy our source and setup working directory
+COPY . /tmp/build
+WORKDIR /tmp/build
+
+# Build our Nix application
+RUN nix \
+    --extra-experimental-features "nix-command flakes" \
+    --option filter-syscalls false \
+    build
+
+# Copy the Nix store closure - all dependencies our app needs
+RUN mkdir /tmp/nix-store-closure
+RUN cp -R $(nix-store -qR result/) /tmp/nix-store-closure
+
+# Final minimal image
+FROM scratch
+WORKDIR /app
+
+# Copy the Nix store closure and our built application
+COPY --from=builder /tmp/nix-store-closure /nix/store
+COPY --from=builder /tmp/build/result /app
+
+# Set the entrypoint
+CMD ["/app/bin/cdp-pipeline-workflow"]

--- a/Dockerfile.nix
+++ b/Dockerfile.nix
@@ -15,13 +15,22 @@ RUN nix \
 RUN mkdir /tmp/nix-store-closure
 RUN cp -R $(nix-store -qR result/) /tmp/nix-store-closure
 
-# Final minimal image
+# Final minimal image with CA certificates
+FROM alpine:latest AS certs
+RUN apk --no-cache add ca-certificates
+
 FROM scratch
 WORKDIR /app
+
+# Copy CA certificates for TLS
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy the Nix store closure and our built application
 COPY --from=builder /tmp/nix-store-closure /nix/store
 COPY --from=builder /tmp/build/result /app
+
+# Set SSL certificate path
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 # Set the entrypoint
 CMD ["/app/bin/cdp-pipeline-workflow"]

--- a/flake.lock
+++ b/flake.lock
@@ -18,26 +18,6 @@
         "type": "github"
       }
     },
-    "nix2container": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1752002763,
-        "narHash": "sha256-JYAkdZvpdSx9GUoHPArctYMypSONob4DYKRkOubUWtY=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "4f2437f6a1844b843b380d483087ae6d461240ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1751984180,
@@ -57,7 +37,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nix2container": "nix2container",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -97,15 +97,15 @@
           
           IMAGE_NAME="obsrvr-flow-pipeline"
           TAG="''${1:-latest}"
-          REGISTRY="''${2:-docker.io}"
+          USERNAME="''${2:-withobsrvr}"
           
           echo "Building production container with Docker..."
-          ${pkgs.docker}/bin/docker build -f Dockerfile.nix -t "$REGISTRY/$IMAGE_NAME:$TAG" .
+          ${pkgs.docker}/bin/docker build -f Dockerfile.nix -t "docker.io/$USERNAME/$IMAGE_NAME:$TAG" .
           
           echo "Pushing to DockerHub..."
-          ${pkgs.docker}/bin/docker push "$REGISTRY/$IMAGE_NAME:$TAG"
+          ${pkgs.docker}/bin/docker push "docker.io/$USERNAME/$IMAGE_NAME:$TAG"
           
-          echo "Successfully pushed $REGISTRY/$IMAGE_NAME:$TAG"
+          echo "Successfully pushed docker.io/$USERNAME/$IMAGE_NAME:$TAG"
         '';
 
         pushToDev = pkgs.writeShellScriptBin "push-to-dockerhub-dev" ''
@@ -113,15 +113,15 @@
           
           IMAGE_NAME="cdp-pipeline-dev"
           TAG="''${1:-latest}"
-          REGISTRY="''${2:-docker.io}"
+          USERNAME="''${2:-withobsrvr}"
           
           echo "Building development container with Docker..."
-          ${pkgs.docker}/bin/docker build -f Dockerfile.nix -t "$REGISTRY/$IMAGE_NAME:$TAG" .
+          ${pkgs.docker}/bin/docker build -f Dockerfile.nix -t "docker.io/$USERNAME/$IMAGE_NAME:$TAG" .
           
           echo "Pushing to DockerHub..."
-          ${pkgs.docker}/bin/docker push "$REGISTRY/$IMAGE_NAME:$TAG"
+          ${pkgs.docker}/bin/docker push "docker.io/$USERNAME/$IMAGE_NAME:$TAG"
           
-          echo "Successfully pushed $REGISTRY/$IMAGE_NAME:$TAG"
+          echo "Successfully pushed docker.io/$USERNAME/$IMAGE_NAME:$TAG"
         '';
 
       in

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
           czmq
           libsodium.dev  # Use dev output for pkg-config files
           arrow-cpp
+          duckdb        # Add duckdb dependency
           pkg-config
           gcc
           gnumake
@@ -69,18 +70,17 @@
           # Enable CGO
           env.CGO_ENABLED = "1";
 
-          # Build flags
+          # Build flags  
           ldflags = [
             "-s"
             "-w"
-            "-extldflags=-static"
           ];
 
           # Set build environment
           preBuild = ''
             export CGO_ENABLED=1
-            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium.dev}/include -I${pkgs.arrow-cpp}/include"
-            export CGO_LDFLAGS="-L${pkgs.zeromq}/lib -L${pkgs.czmq}/lib -L${pkgs.libsodium}/lib -L${pkgs.arrow-cpp}/lib"
+            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium.dev}/include -I${pkgs.arrow-cpp}/include -I${pkgs.duckdb}/include"
+            export CGO_LDFLAGS="-L${pkgs.zeromq}/lib -L${pkgs.czmq}/lib -L${pkgs.libsodium}/lib -L${pkgs.arrow-cpp}/lib -L${pkgs.duckdb}/lib"
             export PKG_CONFIG_PATH="${pkgs.zeromq}/lib/pkgconfig:${pkgs.czmq}/lib/pkgconfig:${pkgs.libsodium.dev}/lib/pkgconfig:${pkgs.arrow-cpp}/lib/pkgconfig"
           '';
 
@@ -256,8 +256,8 @@
             
             # Set up CGO environment
             export CGO_ENABLED=1
-            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium.dev}/include -I${pkgs.arrow-cpp}/include"
-            export CGO_LDFLAGS="-L${pkgs.zeromq}/lib -L${pkgs.czmq}/lib -L${pkgs.libsodium}/lib -L${pkgs.arrow-cpp}/lib"
+            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium.dev}/include -I${pkgs.arrow-cpp}/include -I${pkgs.duckdb}/include"
+            export CGO_LDFLAGS="-L${pkgs.zeromq}/lib -L${pkgs.czmq}/lib -L${pkgs.libsodium}/lib -L${pkgs.arrow-cpp}/lib -L${pkgs.duckdb}/lib"
             export PKG_CONFIG_PATH="${pkgs.zeromq}/lib/pkgconfig:${pkgs.czmq}/lib/pkgconfig:${pkgs.libsodium.dev}/lib/pkgconfig:${pkgs.arrow-cpp}/lib/pkgconfig"
             
             # Set custom prompt to indicate Nix development environment

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,13 @@
         systemDeps = with pkgs; [
           zeromq
           czmq
-          libsodium
+          libsodium.dev  # Use dev output for pkg-config files
           arrow-cpp
           pkg-config
           gcc
           gnumake
           cmake
-          openssl
+          openssl.dev    # Use dev output for pkg-config files
         ];
 
         # Development tools
@@ -61,7 +61,7 @@
 
           # IMPORTANT: Update this hash after first build attempt
           # Run: nix build 2>&1 | grep "got:" | awk '{print $2}'
-          vendorHash = "sha256-txBhNeCZYonzYJr3V7VyqEr638kzH38wXTwt1XbP7WM=";
+          vendorHash = "sha256-IKOfpBARjXmrELW6ZvUzQ2OSvmGttpnzx6W7y/tr08g=";
 
           nativeBuildInputs = systemDeps;
           buildInputs = systemDeps;
@@ -79,9 +79,9 @@
           # Set build environment
           preBuild = ''
             export CGO_ENABLED=1
-            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium}/include -I${pkgs.arrow-cpp}/include"
+            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium.dev}/include -I${pkgs.arrow-cpp}/include"
             export CGO_LDFLAGS="-L${pkgs.zeromq}/lib -L${pkgs.czmq}/lib -L${pkgs.libsodium}/lib -L${pkgs.arrow-cpp}/lib"
-            export PKG_CONFIG_PATH="${pkgs.zeromq}/lib/pkgconfig:${pkgs.czmq}/lib/pkgconfig:${pkgs.libsodium}/lib/pkgconfig:${pkgs.arrow-cpp}/lib/pkgconfig"
+            export PKG_CONFIG_PATH="${pkgs.zeromq}/lib/pkgconfig:${pkgs.czmq}/lib/pkgconfig:${pkgs.libsodium.dev}/lib/pkgconfig:${pkgs.arrow-cpp}/lib/pkgconfig"
           '';
 
           # Skip tests as they don't exist yet
@@ -256,9 +256,9 @@
             
             # Set up CGO environment
             export CGO_ENABLED=1
-            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium}/include -I${pkgs.arrow-cpp}/include"
+            export CGO_CFLAGS="-I${pkgs.zeromq}/include -I${pkgs.czmq}/include -I${pkgs.libsodium.dev}/include -I${pkgs.arrow-cpp}/include"
             export CGO_LDFLAGS="-L${pkgs.zeromq}/lib -L${pkgs.czmq}/lib -L${pkgs.libsodium}/lib -L${pkgs.arrow-cpp}/lib"
-            export PKG_CONFIG_PATH="${pkgs.zeromq}/lib/pkgconfig:${pkgs.czmq}/lib/pkgconfig:${pkgs.libsodium}/lib/pkgconfig:${pkgs.arrow-cpp}/lib/pkgconfig"
+            export PKG_CONFIG_PATH="${pkgs.zeromq}/lib/pkgconfig:${pkgs.czmq}/lib/pkgconfig:${pkgs.libsodium.dev}/lib/pkgconfig:${pkgs.arrow-cpp}/lib/pkgconfig"
             
             # Set custom prompt to indicate Nix development environment
             export PS1="\[\033[1;34m\][nix-cdp]\[\033[0m\] \[\033[1;32m\]\u@\h\[\033[0m\]:\[\033[1;34m\]\w\[\033[0m\]\$ "

--- a/flake.nix
+++ b/flake.nix
@@ -4,17 +4,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    nix2container = {
-      url = "github:nlewo/nix2container";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix2container }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        nix2containerPkgs = nix2container.packages.${system};
 
         # System dependencies required for CGO
         systemDeps = with pkgs; [
@@ -33,8 +28,7 @@
         # Development tools
         devTools = with pkgs; [
           # Container tools
-          nerdctl
-          containerd
+          docker
           skopeo
           
           # Development utilities
@@ -96,91 +90,6 @@
           };
         };
 
-        # Create a minimal production container
-        container-prod = nix2containerPkgs.nix2container.buildImage {
-          name = "obsrvr-flow-pipeline";
-          tag = "latest";
-          
-          copyToRoot = pkgs.buildEnv {
-            name = "container-root";
-            paths = with pkgs; [
-              cdp-pipeline
-              coreutils
-              bash
-              cacert
-              tzdata
-              # Runtime libraries
-              zeromq
-              czmq
-              libsodium
-            ];
-            pathsToLink = [ "/bin" "/lib" "/share" ];
-          };
-
-          config = {
-            Entrypoint = [ "${cdp-pipeline}/bin/cdp-pipeline-workflow" ];
-            WorkingDir = "/app";
-            User = "1000:1000";
-            Env = [
-              "PATH=/bin"
-              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-            ];
-            ExposedPorts = {
-              "8080/tcp" = {};
-            };
-          };
-        };
-
-        # Create a development container with debugging tools
-        container-dev = nix2containerPkgs.nix2container.buildImage {
-          name = "cdp-pipeline-dev";
-          tag = "latest";
-          
-          copyToRoot = pkgs.buildEnv {
-            name = "container-dev-root";
-            paths = with pkgs; [
-              cdp-pipeline
-              coreutils
-              bash
-              cacert
-              tzdata
-              # Runtime libraries
-              zeromq
-              czmq
-              libsodium
-              # Development tools
-              curl
-              jq
-              yq-go
-              vim
-              htop
-              nettools
-              iputils
-              sudo
-            ];
-            pathsToLink = [ "/bin" "/lib" "/share" "/etc" ];
-          };
-
-          config = {
-            Entrypoint = [ "/bin/bash" ];
-            WorkingDir = "/app";
-            User = "1000:1000";
-            Env = [
-              "PATH=/bin"
-              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-              "DEV_MODE=true"
-              "LOG_LEVEL=debug"
-            ];
-            ExposedPorts = {
-              "8080/tcp" = {};
-              "5555/tcp" = {}; # ZeroMQ
-            };
-            Volumes = {
-              "/app/config" = {};
-              "/app/data" = {};
-            };
-          };
-        };
 
         # Docker push scripts (standalone - build containers on demand)
         pushToProd = pkgs.writeShellScriptBin "push-to-dockerhub-prod" ''
@@ -190,17 +99,11 @@
           TAG="''${1:-latest}"
           REGISTRY="''${2:-docker.io}"
           
-          echo "Building production container..."
-          CONTAINER_PATH=$(nix build --no-link --print-out-paths .#container-prod)
-          
-          echo "Loading container image..."
-          ${pkgs.nerdctl}/bin/nerdctl load < "$CONTAINER_PATH"
-          
-          echo "Tagging image..."
-          ${pkgs.nerdctl}/bin/nerdctl tag "$IMAGE_NAME:latest" "$REGISTRY/$IMAGE_NAME:$TAG"
+          echo "Building production container with Docker..."
+          ${pkgs.docker}/bin/docker build -f Dockerfile.nix -t "$REGISTRY/$IMAGE_NAME:$TAG" .
           
           echo "Pushing to DockerHub..."
-          ${pkgs.nerdctl}/bin/nerdctl push "$REGISTRY/$IMAGE_NAME:$TAG"
+          ${pkgs.docker}/bin/docker push "$REGISTRY/$IMAGE_NAME:$TAG"
           
           echo "Successfully pushed $REGISTRY/$IMAGE_NAME:$TAG"
         '';
@@ -212,17 +115,11 @@
           TAG="''${1:-latest}"
           REGISTRY="''${2:-docker.io}"
           
-          echo "Building development container..."
-          CONTAINER_PATH=$(nix build --no-link --print-out-paths .#container-dev)
-          
-          echo "Loading container image..."
-          ${pkgs.nerdctl}/bin/nerdctl load < "$CONTAINER_PATH"
-          
-          echo "Tagging image..."
-          ${pkgs.nerdctl}/bin/nerdctl tag "$IMAGE_NAME:latest" "$REGISTRY/$IMAGE_NAME:$TAG"
+          echo "Building development container with Docker..."
+          ${pkgs.docker}/bin/docker build -f Dockerfile.nix -t "$REGISTRY/$IMAGE_NAME:$TAG" .
           
           echo "Pushing to DockerHub..."
-          ${pkgs.nerdctl}/bin/nerdctl push "$REGISTRY/$IMAGE_NAME:$TAG"
+          ${pkgs.docker}/bin/docker push "$REGISTRY/$IMAGE_NAME:$TAG"
           
           echo "Successfully pushed $REGISTRY/$IMAGE_NAME:$TAG"
         '';
@@ -244,8 +141,7 @@
             echo "Available commands:"
             echo "  go build -o cdp-pipeline-workflow        - Build Go application locally"
             echo "  nix build                                - Build the Go application with Nix"
-            echo "  nix build .#container-prod               - Build production container"
-            echo "  nix build .#container-dev                - Build development container"
+            echo "  docker build -f Dockerfile.nix .         - Build Docker container"
             echo "  nix build .#push-to-dockerhub-prod       - Build DockerHub push script (prod)"
             echo "  nix build .#push-to-dockerhub-dev        - Build DockerHub push script (dev)"
             echo ""
@@ -269,8 +165,6 @@
         packages = {
           default = cdp-pipeline;
           cdp-pipeline = cdp-pipeline;
-          container-prod = container-prod;
-          container-dev = container-dev;
           push-to-dockerhub-prod = pushToProd;
           push-to-dockerhub-dev = pushToDev;
         };

--- a/pkg/processor/base/processor.go
+++ b/pkg/processor/base/processor.go
@@ -80,7 +80,7 @@ type Event struct {
 
 // ExtractEntryFromIngestChange gets the most recent state of an entry from an ingestion change
 func ExtractEntryFromIngestChange(change ingest.Change) (xdr.LedgerEntry, xdr.LedgerEntryChangeType, bool, error) {
-	switch changeType := change.LedgerEntryChangeType(); changeType {
+	switch changeType := change.ChangeType; changeType {
 	case xdr.LedgerEntryChangeTypeLedgerEntryCreated, xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
 		return *change.Post, changeType, false, nil
 	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:
@@ -173,7 +173,7 @@ type TestTransaction struct {
 
 // ExtractEntryFromChange gets the most recent state of an entry from an ingestio change, as well as if the entry was deleted
 func ExtractEntryFromChange(change ingest.Change) (xdr.LedgerEntry, xdr.LedgerEntryChangeType, bool, error) {
-	switch changeType := change.LedgerEntryChangeType(); changeType {
+	switch changeType := change.ChangeType; changeType {
 	case xdr.LedgerEntryChangeTypeLedgerEntryCreated, xdr.LedgerEntryChangeTypeLedgerEntryUpdated:
 		return *change.Post, changeType, false, nil
 	case xdr.LedgerEntryChangeTypeLedgerEntryRemoved:

--- a/pkg/processor/ledger/latest_ledger.go
+++ b/pkg/processor/ledger/latest_ledger.go
@@ -231,7 +231,7 @@ func getSorobanMetrics(tx ingest.LedgerTransaction) sorobanMetrics {
 
 	sMetrics.resourceFee = int64(sorobanData.ResourceFee)
 	sMetrics.instructions = uint32(sorobanData.Resources.Instructions)
-	sMetrics.readBytes = uint32(sorobanData.Resources.ReadBytes)
+	sMetrics.readBytes = uint32(sorobanData.Resources.DiskReadBytes)
 	sMetrics.writeBytes = uint32(sorobanData.Resources.WriteBytes)
 
 	return sMetrics

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Default values
+CONFIG_FILE="${1:-config/base/pipeline_config.yaml}"
+IMAGE_NAME="docker.io/withobsrvr/cdp-pipeline-dev:latest"
+
+echo "Running CDP Pipeline with Docker container..."
+echo "Config file: $CONFIG_FILE"
+echo "Image: $IMAGE_NAME"
+
+# Run the container with volume mounts
+docker run --rm \
+  -v "$(pwd)/config:/app/config" \
+  -v "$(pwd)/output:/app/output" \
+  -v "$(pwd)/data:/app/data" \
+  -e "CONFIG_FILE=/app/$CONFIG_FILE" \
+  "$IMAGE_NAME" \
+  /app/bin/cdp-pipeline-workflow -config "/app/$CONFIG_FILE"


### PR DESCRIPTION
This pull request introduces significant changes to the build and containerization process, as well as minor updates to the codebase. The most notable updates include migrating from `nix2container` to a `Dockerfile`-based approach for container builds, modifying dependencies and build configurations in `flake.nix`, and making minor code adjustments to improve functionality and maintainability.

### Containerization Updates:
* Added a new `Dockerfile.nix` to define a multi-stage build process for creating minimal Docker images using Nix. This replaces the previous `nix2container`-based approach.
* Removed `container-prod` and `container-dev` definitions from `flake.nix`, along with their respective build commands and dependencies. These have been replaced by Docker-based workflows. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L99-R124) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L247-R144) [[3]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L272-L273)
* Updated the Docker push scripts in `flake.nix` to use Docker CLI commands instead of `nerdctl`.

### Dependency and Build Configuration Updates:
* Added `duckdb` as a new dependency and switched to `.dev` outputs for `libsodium` and `openssl` to include necessary development files.
* Updated `vendorHash` in `flake.nix` to reflect changes in dependencies.
* Adjusted `CGO_CFLAGS`, `CGO_LDFLAGS`, and `PKG_CONFIG_PATH` to include `duckdb` and updated paths for `.dev` outputs. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L76-R78) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L259-R157)

### Code Adjustments:
* Replaced `LedgerEntryChangeType()` with `ChangeType` in two functions in `pkg/processor/base/processor.go` to simplify access to the change type. [[1]](diffhunk://#diff-d8f963432222546f7b8c5e1e53031e06189d25fa794aa50c8c4e120cdcd7e916L83-R83) [[2]](diffhunk://#diff-d8f963432222546f7b8c5e1e53031e06189d25fa794aa50c8c4e120cdcd7e916L176-R176)
* Updated `getSorobanMetrics` in `pkg/processor/ledger/latest_ledger.go` to use `DiskReadBytes` instead of `ReadBytes` for resource metrics.

### New Script:
* Added `run-container.sh` to simplify running the development container with appropriate volume mounts and environment variables.